### PR TITLE
Error handling for file search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+efar.elc


### PR DESCRIPTION
1. If the directory or file processed during search is not readable then it's added to the list of skipped files, but search is not aborted.
2. Information about skipped files is added to the search result details.
3. Common unexpected errors occurred during search are reported in the status. Search is aborted with failure in such case.